### PR TITLE
linter: Rename command to `lint`; use Abscissa statuses

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,10 +1,10 @@
 //! `rustsec-admin` CLI subcommands
 
-mod check;
+mod lint;
 mod version;
 mod web;
 
-use self::{check::CheckCmd, version::VersionCmd, web::WebCmd};
+use self::{lint::LintCmd, version::VersionCmd, web::WebCmd};
 use crate::config::AppConfig;
 use abscissa_core::{Command, Configurable, Help, Options, Runnable};
 use std::path::PathBuf;
@@ -12,9 +12,9 @@ use std::path::PathBuf;
 /// `rustsec-admin` CLI subcommands
 #[derive(Command, Debug, Options, Runnable)]
 pub enum AdminCmd {
-    /// The `check` subcommand
-    #[options(help = "check that the Advisory DB is well-formed")]
-    Check(CheckCmd),
+    /// The `lint` subcommand
+    #[options(help = "lint Advisory DB and ensure is well-formed")]
+    Lint(LintCmd),
 
     /// The `web` subcommand
     #[options(help = "render advisory Markdown files for the rustsec.org web site")]

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -1,18 +1,18 @@
-//! `rustsec-admin check` subcommand
+//! `rustsec-admin lint` subcommand
 
 use abscissa_core::{Command, Runnable};
 use gumdrop::Options;
 use std::path::{Path, PathBuf};
 
-/// `rustsec-admin check` subcommand
+/// `rustsec-admin lint` subcommand
 #[derive(Command, Debug, Default, Options)]
-pub struct CheckCmd {
+pub struct LintCmd {
     /// Path to the advisory database
     #[options(free, help = "filesystem path to the RustSec advisory DB git repo")]
     path: Vec<PathBuf>,
 }
 
-impl Runnable for CheckCmd {
+impl Runnable for LintCmd {
     fn run(&self) {
         let repo_path = match self.path.len() {
             0 => Path::new("."),

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -8,16 +8,16 @@ lazy_static! {
     pub static ref RUNNER: CmdRunner = CmdRunner::default();
 }
 
-/// Run `rustsec-admin check` against a freshly fetched advisory DB repo
+/// Run `rustsec-admin lint` against a freshly fetched advisory DB repo
 #[test]
-fn check_advisory_db() {
+fn lint_advisory_db() {
     // Fetch the advisory database
     rustsec::Repository::fetch_default_repo().unwrap();
 
     let mut runner = RUNNER.clone();
 
     runner
-        .arg("check")
+        .arg("lint")
         .arg(&rustsec::Repository::default_path())
         .capture_stdout()
         .status()


### PR DESCRIPTION
Renames the previous `check` command to `lint` and changes the status display to use standard Abscissa status macros.