### PR TITLE
Assign id subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cargo-lock 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1393,11 +1393,12 @@ name = "rustsec-admin"
 version = "0.1.1"
 dependencies = [
  "abscissa_core 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crates_io_api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustsec 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustsec 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2258,7 +2259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum reqwest 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)" = "02b7e953e14c6f3102b7e8d1f1ee3abf5ecee80b427f5565c9389835cecae95c"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum rustsec 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98a9fdef7445a6747fc2288b0d3f66de53dc38f1f4f3e232214bfec2f3deb333"
+"checksum rustsec 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bcdbdffa54886a5cd9025a2881e148351183d5a8ec83b4b9f87a00427756d44"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,11 @@ abscissa_core = "0.5"
 crates_io_api = "0.5"
 gumdrop = "0.7"
 handlebars = "3"
-rustsec = "0.20"
+rustsec = "0.20.1"
 serde = { version = "1", features = ["serde_derive"] }
 termcolor = "1"
 thiserror = "1"
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 abscissa_core = { version = "0.5", features = ["testing"] }

--- a/src/assigner.rs
+++ b/src/assigner.rs
@@ -1,0 +1,135 @@
+//! RustSec Advisory DB tool to assign ids
+
+use crate::error::ErrorKind;
+use crate::prelude::*;
+use chrono::Datelike;
+use rustsec::advisory::id::Kind;
+use rustsec::collection::Collection;
+use rustsec::Advisory;
+use std::fs::File;
+use std::io::{BufRead, BufReader, LineWriter, Write};
+use std::{collections::HashMap, fs, path::Path, process::exit};
+
+/// assign ids to advisories in a particular repo_path
+pub fn assign_ids(repo_path: &Path) {
+    let repo = rustsec::Repository::open(repo_path).unwrap_or_else(|e| {
+        status_err!(
+            "couldn't open advisory DB repo from {}: {}",
+            repo_path.display(),
+            e
+        );
+        exit(1);
+    });
+
+    // Ensure Advisories.toml parses
+    let db = rustsec::Database::load(&repo).unwrap();
+    let advisories = db.iter();
+
+    // Ensure we're parsing some advisories
+    if advisories.len() == 0 {
+        status_err!("no advisories found!");
+        exit(1);
+    }
+
+    status_ok!(
+        "Loaded",
+        "{} security advisories (from {})",
+        advisories.len(),
+        repo_path.display()
+    );
+
+    let mut highest_id = HashMap::new();
+
+    for advisory in advisories {
+        let advisory_clone = advisory.clone();
+        let metadata = advisory_clone.metadata;
+        let id = metadata.id;
+        let year = metadata.date.to_chrono_date().unwrap().year();
+        if let Kind::RUSTSEC = id.kind() {
+            let id_num = id.numerical_part().unwrap();
+            if let Some(&number) = highest_id.get(&year) {
+                if number < id_num {
+                    highest_id.insert(year, id_num);
+                }
+            } else {
+                highest_id.insert(year, id_num);
+            }
+        }
+    }
+
+    let mut collection_strs = vec![];
+    let crates_str = Collection::Crates.to_string();
+    let rust_str = Collection::Rust.to_string();
+    collection_strs.push(crates_str);
+    collection_strs.push(rust_str);
+    for collection_str in collection_strs {
+        assign_ids_across_directory(collection_str, repo_path, &mut highest_id);
+    }
+}
+
+///Assign ids to files with placeholder IDs within the directory defined by dir_path
+fn assign_ids_across_directory(
+    collection_str: String,
+    repo_path: &Path,
+    highest_ids: &mut HashMap<i32, u32>,
+) {
+    let dir_path = repo_path.join(collection_str);
+    if let Ok(collection_entry) = fs::read_dir(dir_path) {
+        for dir_entry in collection_entry {
+            let unwrapped_dir_entry = dir_entry.unwrap();
+            let dir_name = unwrapped_dir_entry.file_name().into_string().unwrap();
+            let dir_path = unwrapped_dir_entry.path();
+            let dir_path_clone = dir_path.clone();
+            for advisory_entry in fs::read_dir(dir_path).unwrap() {
+                let unwrapped_advisory = advisory_entry.unwrap();
+                let advisory_path = unwrapped_advisory.path();
+                let advisory_path_clone = advisory_path.clone();
+                let advisory_path_for_reading = advisory_path.clone();
+                let advisory_path_for_deleting = advisory_path.clone();
+                let displayed_advisory_path = advisory_path.display();
+                let advisory_filename = unwrapped_advisory.file_name();
+                let advisory_filename_str = advisory_filename.into_string().unwrap();
+                if advisory_filename_str.contains("RUSTSEC-0000-0000") {
+                    let toml = fs::read_to_string(advisory_path_clone)
+                        .map_err(|e| {
+                            format_err!(
+                                ErrorKind::Io,
+                                "Couldn't open {}: {}",
+                                displayed_advisory_path,
+                                e
+                            );
+                        })
+                        .unwrap();
+                    let advisory = toml.parse::<Advisory>().unwrap();
+                    let date = advisory.metadata.date;
+                    let year = date.to_chrono_date().unwrap().year();
+                    let new_id = highest_ids.get(&year).unwrap() + 1;
+                    let year_str = year.to_string();
+                    let string_id = format!("RUSTSEC-{}-{:04}", year_str, new_id);
+                    let new_filename = format!("{}.toml", string_id);
+                    let new_path = dir_path_clone.join(new_filename);
+                    let original_file = File::open(advisory_path_for_reading).unwrap();
+                    let reader = BufReader::new(original_file);
+                    let new_file = File::create(new_path).unwrap();
+                    let mut writer = LineWriter::new(new_file);
+                    for line in reader.lines() {
+                        let current_line = line.unwrap();
+                        if current_line.contains("id = ") {
+                            writer
+                                .write_all(format!("id = \"{}\"\n", string_id).as_ref())
+                                .unwrap();
+                        } else {
+                            let current_line_with_newline = format!("{}\n", current_line);
+                            writer
+                                .write_all(current_line_with_newline.as_ref())
+                                .unwrap();
+                        }
+                    }
+                    highest_ids.insert(year, new_id);
+                    fs::remove_file(advisory_path_for_deleting).unwrap();
+                    status_ok!("Assignment", "Assigned {} to {}", string_id, dir_name);
+                }
+            }
+        }
+    }
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,10 +1,11 @@
 //! `rustsec-admin` CLI subcommands
 
+mod assignid;
 mod lint;
 mod version;
 mod web;
 
-use self::{lint::LintCmd, version::VersionCmd, web::WebCmd};
+use self::{assignid::AssignIdCmd, lint::LintCmd, version::VersionCmd, web::WebCmd};
 use crate::config::AppConfig;
 use abscissa_core::{Command, Configurable, Help, Options, Runnable};
 use std::path::PathBuf;
@@ -27,6 +28,10 @@ pub enum AdminCmd {
     /// The `version` subcommand
     #[options(help = "display version information")]
     Version(VersionCmd),
+
+    /// The `assign-id` subcommand
+    #[options(help = "assigning RUSTSEC ids to new vulnerabilities")]
+    AssignId(AssignIdCmd),
 }
 
 impl Configurable<AppConfig> for AdminCmd {

--- a/src/commands/assignid.rs
+++ b/src/commands/assignid.rs
@@ -1,0 +1,27 @@
+//! `rustsec-admin assignid` subcommand
+//!
+//! Assigns RUSTSEC ids to new vulnerabilities
+
+use abscissa_core::{Command, Runnable};
+use gumdrop::Options;
+use std::path::{Path, PathBuf};
+
+/// `rustsec-admin lint` subcommand
+#[derive(Command, Debug, Default, Options)]
+pub struct AssignIdCmd {
+    /// Path to the advisory database
+    #[options(free, help = "filesystem path to the RustSec advisory DB git repo")]
+    path: Vec<PathBuf>,
+}
+
+impl Runnable for AssignIdCmd {
+    fn run(&self) {
+        let repo_path = match self.path.len() {
+            0 => Path::new("."),
+            1 => self.path[0].as_path(),
+            _ => Self::print_usage_and_exit(&[]),
+        };
+
+        crate::assigner::assign_ids(repo_path);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![forbid(unsafe_code)]
 
 pub mod application;
+pub mod assigner;
 pub mod commands;
 pub mod config;
 pub mod error;


### PR DESCRIPTION
A PR to resolve #30 you can use it by writing the following command `rustsec-admin assign-id <insert repo path here>`. The files it fills are files whose filename and ID are placeholder RUSTSEC IDs.