### PR TITLE
Add argument to change where website is outputted

### DIFF
--- a/src/commands/web.rs
+++ b/src/commands/web.rs
@@ -2,15 +2,28 @@
 //!
 //! https://rustsec.org
 
+use std::path::PathBuf;
+
 use abscissa_core::{Command, Runnable};
 use gumdrop::Options;
 
 /// `rustsec-admin web` subcommand
 #[derive(Command, Debug, Default, Options)]
-pub struct WebCmd {}
+pub struct WebCmd {
+    #[options(
+        free,
+        help = "path to output the generated website (defaults to _site/)"
+    )]
+    path: Vec<PathBuf>,
+}
 
 impl Runnable for WebCmd {
     fn run(&self) {
-        crate::web::render_advisories();
+        let output_folder = match self.path.len() {
+            0 => PathBuf::from("_site/"),
+            1 => self.path[0].clone(),
+            _ => Self::print_usage_and_exit(&[]),
+        };
+        crate::web::render_advisories(output_folder);
     }
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -29,14 +29,12 @@ struct AdvisoryTemplate<'a> {
 }
 
 /// Render all advisories using the Markdown template
-pub fn render_advisories() {
+pub fn render_advisories(output_folder: PathBuf) {
     let mut advisories: Vec<rustsec::Advisory> = rustsec::Database::fetch()
         .unwrap()
         .iter()
         .map(|advisory| advisory.to_owned())
         .collect();
-
-    let output_folder = PathBuf::from("_site");
 
     // Render individual advisory pages.
     let advisories_folder = output_folder.join("advisories");


### PR DESCRIPTION
This lets you do `rustsec-admin web xyz` to change where the website is generated to. We'll use this in the github action for `advisory-db` to output to the repo folder.