### PR TITLE
Web: Add pages per package

### DIFF
--- a/src/web/templates/advisory-content.html
+++ b/src/web/templates/advisory-content.html
@@ -29,13 +29,13 @@
         {% match advisory.metadata.collection %}
         {% when Some with (collection) %}
         {% if collection.to_string() == "crates" %}
-        {{ advisory.metadata.package }} (<a
-          href="https://crates.io/crates/{{ advisory.metadata.package }}">crates.io</a>)
+        <a href="/packages/{{ advisory.metadata.package }}.html">{{ advisory.metadata.package }}</a>
+          (<a href="https://crates.io/crates/{{ advisory.metadata.package }}">crates.io</a>)
         {% else %}
-        <code>{{ advisory.metadata.package }}</code>
+        <code><a href="/packages/{{ advisory.metadata.package }}.html">{{ advisory.metadata.package }}</a></code>
         {% endif %}
         {% when None %}
-        <code>{{ advisory.metadata.package }}</code>
+        <code><a href="/packages/{{ advisory.metadata.package }}.html">{{ advisory.metadata.package }}</a></code>
         {% endmatch %}
       </dd>
 

--- a/src/web/templates/package-advisories.html
+++ b/src/web/templates/package-advisories.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block title %}Advisories for package {{ package }}{% endblock %}
+
+{% block content %}
+<main class="advisories">
+  <article>
+
+    <header>
+      <h1>Advisories for {{ package }}</h1>
+    </header>
+
+    <ul>
+      {% for (advisory, rendered_title, advisory_title_type) in advisories %}
+      <li>
+        <time datetime="{{ advisory.date().as_str() }}">
+          {{ advisory.date() | friendly_date }}
+        </time>
+
+        {% if advisory.metadata.yanked %}
+        <h3><a class="yanked" href="/advisories/{{ advisory.id() }}.html">
+            {{ advisory.id() }}
+          </a></h3>
+        (yanked advisory)
+        {% else %}
+        <h3>
+          <a href="/advisories/{{ advisory.id() }}.html">
+            {{ advisory_title_type }}
+          </a>
+        </h3>
+        <span>{{ rendered_title|safe }}</span>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+  </article>
+</main>
+{% endblock %}


### PR DESCRIPTION
Adds `/packages/${package}.html` pages listing advisories per package, and a link to the package page in each advisory.

We could also add a package index in `/packages/` at some point.

![Screenshot 2021-05-04 at 00-37-12 Advisories for package hyper › RustSec Advisory Database](https://user-images.githubusercontent.com/329388/116941963-f3b56c80-ac70-11eb-8c20-0536bcbc82d8.png)
